### PR TITLE
Gem Update

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ spec = eval(File.read("win32-api.gemspec"))
 def configure_cross_compilation(ext)
   unless RUBY_PLATFORM =~ /mswin|mingw/
     ext.cross_compile = true
-    ext.cross_platform = ['x86-mingw32', 'x64-mingw32', 'x64-mingw-ucrt']
+    ext.cross_platform = ['x64-mingw-ucrt']
   end
 end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,24 +28,8 @@ test_script:
 environment:
   matrix:
     - ruby_version: _trunk
-    - ruby_version: 30-x64
-    - ruby_version: 30
-    - ruby_version: 27-x64
-    - ruby_version: 27
-    - ruby_version: 26-x64
-    - ruby_version: 26
-    - ruby_version: 25-x64
-    - ruby_version: 25
-    - ruby_version: 24-x64
-    - ruby_version: 24
-    - ruby_version: 23-x64
-    - ruby_version: 23
-    - ruby_version: 22-x64
-    - ruby_version: 22
-    - ruby_version: 21-x64
-    - ruby_version: 21
-    - ruby_version: 200-x64
-    - ruby_version: 200
+    - ruby_version: 31-x64
+    - ruby_version: 31
 
 matrix:
   allow_failures:

--- a/win32-api.gemspec
+++ b/win32-api.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'win32-api'
-  spec.version    = '1.10.1'
+  spec.version    = '1.11.0'
   spec.authors    = ['Daniel J. Berger', 'Park Heesob', 'Hiroshi Hatake']
   spec.license    = 'Artistic-2.0'
   spec.email      = 'djberg96@gmail.com'
@@ -12,12 +12,12 @@ Gem::Specification.new do |spec|
   spec.extensions = ['ext/win32/extconf.rb']
   spec.files      = Dir['**/*'].reject{ |f| f.include?('git') }
 
-  spec.required_ruby_version = '>= 1.8.2'
+  spec.required_ruby_version = '>= 3.1.6'
   spec.extra_rdoc_files = ['CHANGES', 'MANIFEST', 'ext/win32/api.c']
 
-  spec.add_development_dependency('test-unit', '>= 2.5.0')
+  spec.add_development_dependency('test-unit', '>= 3.6.7')
   spec.add_development_dependency('rake')
-  spec.add_development_dependency("rake-compiler", ">= 1.1.9")
+  spec.add_development_dependency("rake-compiler", ">= 1.2.9")
 
   spec.description = <<-EOF
     The Win32::API library is meant as a replacement for the Win32API


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Win32-api was showing up in chef-19 as **_win32-api (1.10.1-universal-mingw32)_**. We need it to support ucrt so it needed to be updated. It hasn't been touched in at least 3 years.

This repo doesn't have tests/builds attached to it but it DID pass testing locally (via rake) on a Windows 11 dev system.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
